### PR TITLE
Version History

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,28 @@ will come from a user with a name you choose, e.g. CodeBuildBot
 AWS Secrets Manager instead of the App token.
 
 ### DynamoDB table
- - expected to be named 'branch-build-status', but can be configured
+ - expected to be named 'codebuild-history', but can be configured
  - the following definition:
 
 ```ruby
   AttributeDefinitions [
+    { AttributeName: 'commit_hash', AttributeType: 'S' },
     { AttributeName: 'source_id', AttributeType: 'S' },
-    { AttributeName: 'commit_hash', AttributeType: 'S' }
+    { AttributeName: 'version_key', AttributeType: 'S' }
   ]
   GlobalSecondaryIndexes [
     {
       IndexName: 'commit_hash_index',
       KeySchema: [
-        { AttributeName: 'commit_hash', KeyType: 'HASH' }
+        { AttributeName: 'commit_hash', KeyType: 'HASH' },
+        { AttributeName: 'version_key', KeyType: 'RANGE' }
       ],
-      Projection: { ProjectionType: 'ALL' },
+      Projection: { ProjectionType: 'ALL' }
     }
   ]
   KeySchema [
-    { AttributeName: 'source_id', KeyType: 'HASH' }
+    { AttributeName: 'source_id', KeyType: 'HASH' },
+    { AttributeName: 'version_key', KeyType: 'RANGE' }
   ]
 ```
 
@@ -72,8 +75,8 @@ name:
   ],
   "Effect": "Allow",
   "Resource": [
-    "arn:aws:dynamodb:<your-region>:<your-account-id>:table/branch-build-status",
-    "arn:aws:dynamodb:<your-region>:<your-account-id>:table/branch-build-status/*"
+    "arn:aws:dynamodb:<your-region>:<your-account-id>:table/codebuild-history",
+    "arn:aws:dynamodb:<your-region>:<your-account-id>:table/codbuild-history/*"
   ]
 },
 {
@@ -221,7 +224,7 @@ phases:
       <nobr>--dynamo-table</nobr>
     </td>
     <td>
-      branch-build-status
+      codebuild-history
     </td>
     <td>
       This table must be created and permissions granted to it as described
@@ -287,7 +290,7 @@ phases:
       <nobr>--whitelist-branches</nobr>
     </td>
     <td>
-      master,release
+      master
     </td>
     <td>
       Normally statuses will be stored and notifications sent only for builds

--- a/bin/update-build-status
+++ b/bin/update-build-status
@@ -122,17 +122,16 @@ end.parse!
 config = CodeBuildNotifier::Config.new(command_line_opts)
 build = CodeBuildNotifier::CurrentBuild.new
 history = CodeBuildNotifier::BuildHistory.new(config, build)
-
 last_build = history.last_entry
 build.previous_build = last_build
 
 if build.launched_by_retry?
   # Whenever a build is triggered by a PR or whitelisted branch, we update
-  # the record for that trigger with the commit hash. If a build is then
-  # launched using Retry, the status is updated and are notifications sent
-  # only if the re-tried build was for the latest commit. Otherwise re-trying
-  # an older commit could result in inaccurate notifications.
-  quit(not_latest_commit_in_branch_message(build, config)) unless last_build
+  # the record for that trigger with the commit hash. If a build is
+  # launched using Retry, and there is no history entry for the current
+  # commit hash, then the build is not for a PR or a whitelisted branch,
+  # and should not be tracked.
+  quit(not_pr_or_whitelisted_branch_message(config)) unless last_build
 else
   # We only want to track information for whitelisted branches and branches
   # with open Pull Requests.
@@ -141,8 +140,6 @@ else
   end
 end
 
-# Update record for this project + branch/pr in DynamoDb even if the
-# status hasn't changed, so the latest commit hash is stored.
 history.write_entry(build.source_id) do |new_item|
   cb_puts "Updating dynamo table #{config.dynamo_table} with: #{new_item}"
 end

--- a/lib/codebuild-notifier.rb
+++ b/lib/codebuild-notifier.rb
@@ -17,6 +17,7 @@
 
 require 'codebuild-notifier/config'
 require 'codebuild-notifier/dynamo_base'
+require 'codebuild-notifier/branch_entry'
 require 'codebuild-notifier/build_history'
 require 'codebuild-notifier/current_build'
 require 'codebuild-notifier/git'

--- a/lib/codebuild-notifier.rb
+++ b/lib/codebuild-notifier.rb
@@ -16,9 +16,11 @@
 # along with codebuild-notifier.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'codebuild-notifier/config'
+require 'codebuild-notifier/dynamo_base'
 require 'codebuild-notifier/build_history'
 require 'codebuild-notifier/current_build'
 require 'codebuild-notifier/git'
+require 'codebuild-notifier/project_summary'
 require 'codebuild-notifier/slack_message'
 require 'codebuild-notifier/slack_sender'
 require 'codebuild-notifier/version'

--- a/lib/codebuild-notifier/branch_entry.rb
+++ b/lib/codebuild-notifier/branch_entry.rb
@@ -1,0 +1,54 @@
+# codebuild-notifier
+# Copyright © 2018 Adam Alboyadjian <adam@cassia.tech>
+# Copyright © 2018 Vista Higher Learning, Inc.
+#
+# codebuild-notifier is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# codebuild-notifier is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with codebuild-notifier.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'digest'
+
+module CodeBuildNotifier
+  class BranchEntry < DynamoBase
+    # Creates entries in a partition key with hardcoded primary key.
+    # Within the partition key, there is one record for each github repo.
+    # The 'projects' field in that record is a Map data type, keyed off
+    # project code, containing the status of the last build for that code.
+    def update
+      updates = hash_to_dynamo_update(branch_entry).merge(
+        key: { source_id: source_id, version_key: version_key }
+      )
+      yield updates if block_given?
+      update_item(updates)
+    end
+
+    private def branch_entry
+      {
+        branch_name: current_build.branch_name,
+        build_id: current_build.build_id,
+        commit_hash: source_id,
+        git_repo_url: current_build.git_repo_url,
+        source_ref: current_build.source_ref,
+        status: current_build.status,
+        timestamp: current_build.start_time.to_i
+      }
+    end
+
+    private def source_id
+      current_build.project_code
+    end
+
+    private def version_key
+      Digest::MD5.hexdigest(current_build.source_ref)
+    end
+  end
+end

--- a/lib/codebuild-notifier/build_history.rb
+++ b/lib/codebuild-notifier/build_history.rb
@@ -40,6 +40,7 @@ module CodeBuildNotifier
       update_item(updates)
 
       ProjectSummary.new(config, current_build).update
+      BranchEntry.new(config, current_build).update
     end
 
     # The commit hash and project code are used to find which Pull Request

--- a/lib/codebuild-notifier/build_history.rb
+++ b/lib/codebuild-notifier/build_history.rb
@@ -78,11 +78,7 @@ module CodeBuildNotifier
     end
 
     private def new_entry
-      {
-        commit_hash: current_build.commit_hash,
-        project_code: current_build.project_code,
-        status: current_build.status
-      }.tap do |memo|
+      current_build.history_fields.tap do |memo|
         # If launched via manual re-try instead of via a webhook, we don't
         # want to overwrite the current source_ref value that tells us which
         # branch or pull request originally created the dynamo record.

--- a/lib/codebuild-notifier/build_history.rb
+++ b/lib/codebuild-notifier/build_history.rb
@@ -33,18 +33,22 @@ module CodeBuildNotifier
     end
 
     def last_entry
+      return @last_entry if defined?(@last_entry)
       # If this build was launched using the Retry command from the console
       # or api we don't have a Pull Request or branch name to use in the
       # primary key, so we query by commit hash and project instead.
-      item = launched_by_retry? ? find_by_commit_and_project : find_by_id
+      item = launched_by_retry? ? find_by_commit : find_by_id
 
       # Provide .dot access to hash values from Dynamo item.
-      item && Hashie::Mash.new(item)
+      @last_entry = item && Hashie::Mash.new(item)
     end
 
     def write_entry(source_id)
       updates = hash_to_dynamo_update(new_entry).merge(
-        key: { source_id: source_id }
+        key: {
+          source_id: source_id,
+          version_key: version_key
+        }
       )
 
       yield updates if block_given?
@@ -57,24 +61,59 @@ module CodeBuildNotifier
     # The commit hash and project code are used to find which Pull Request
     # or branch the current build belongs to, and the previous build status
     # for that Pull Request or branch.
-    private def find_by_commit_and_project
-      dynamo_client.query(
-        expression_attribute_values: {
-          ':commit_hash' => current_build.commit_hash,
-          ':project_code' => current_build.project_code
-        },
-        filter_expression: 'project_code = :project_code',
+    private def find_by_commit
+      find_latest_version(
+        expression_attribute_values: commit_values,
+        filter_expression: commit_filter,
         index_name: 'commit_hash_index',
-        key_condition_expression: 'commit_hash = :commit_hash',
-        table_name: dynamo_table
-      ).items.first
+        key_condition_expression: 'commit_hash = :commit_hash'
+      )
+    end
+
+    # When searching by commit hash, if the current build source version
+    # is for a PR, only return commits with that PR as the source ref.
+    # If source version is not for a pr, only return source refs beginning
+    # with branch/. This helps protect against the edge case where the same
+    # commit appears in two different PRs, or in a PR and whitelisted branch
+    # besides than the PR head.
+    private def commit_values
+      source_ref_val = if current_build.for_pr?
+                         current_build.source_version
+                       else
+                         'branch/'
+                       end
+      {
+        ':commit_hash' => current_build.commit_hash,
+        ':project_code' => current_build.project_code,
+        ':source_ref' => source_ref_val
+      }
+    end
+
+    private def commit_filter
+      source_ref_condition = if current_build.for_pr?
+                               'source_ref = :source_ref'
+                             else
+                               'begins_with(source_ref, :source_ref)'
+                             end
+      "project_code = :project_code AND #{source_ref_condition}"
     end
 
     private def find_by_id
-      dynamo_client.get_item(
-        key: { 'source_id' => current_build.source_id },
-        table_name: dynamo_table
-      ).item
+      find_latest_version(
+        expression_attribute_values: {
+          ':source_id' => current_build.source_id
+        },
+        key_condition_expression: 'source_id = :source_id'
+      )
+    end
+
+    private def find_latest_version(args)
+      dynamo_client.query(
+        args.merge(
+          scan_index_forward: false, # Reverse sort by range key
+          table_name: dynamo_table
+        )
+      ).items.first
     end
 
     private def new_entry
@@ -86,6 +125,18 @@ module CodeBuildNotifier
           memo[:source_ref] = current_build.trigger
           memo[:branch_name] = branch_name unless branch_name.empty?
         end
+      end
+    end
+
+    # The first component of the version_key is the timestamp for the
+    # first build of the current commit hash. The second component
+    # is the timestamp for the current build. This allows easily finding
+    # either the latest commit, or the latest re-build of a commit.
+    private def version_key
+      if launched_by_retry?
+        "#{last_entry.start_time}_#{current_build.start_time}"
+      else
+        "#{current_build.start_time}_#{current_build.start_time}"
       end
     end
 

--- a/lib/codebuild-notifier/config.rb
+++ b/lib/codebuild-notifier/config.rb
@@ -17,7 +17,7 @@
 
 module CodeBuildNotifier
   class Config
-    DEFAULT_WHITELIST = %w[master release]
+    DEFAULT_WHITELIST = %w[master]
 
     attr_reader :additional_channel, :default_strategy, :dynamo_table, :region,
                 :slack_admins, :slack_secret_name, :whitelist_branches
@@ -27,7 +27,7 @@ module CodeBuildNotifier
     def initialize(
       additional_channel: ENV['CBN_ADDITIONAL_CHANNEL'],
       default_strategy: ENV['CBN_DEFAULT_NOTIFY_STRATEGY'] || 'fail_or_status_change',
-      dynamo_table: ENV['CBN_DYNAMO_TABLE'] || 'branch-build-status',
+      dynamo_table: ENV['CBN_DYNAMO_TABLE'] || 'codebuild-history',
       region: ENV['CBN_AWS_REGION'] || ENV['AWS_REGION'],
       slack_admins: ENV['CBN_SLACK_ADMIN_USERNAMES'],
       slack_secret_name: ENV['CBN_SLACK_SECRET_NAME'] || 'slack/codebuild',

--- a/lib/codebuild-notifier/current_build.rb
+++ b/lib/codebuild-notifier/current_build.rb
@@ -18,7 +18,8 @@
 module CodeBuildNotifier
   class CurrentBuild
     attr_accessor :previous_build
-    attr_reader :build_id, :commit_hash, :git_repo_url, :status_code, :trigger
+    attr_reader :build_id, :commit_hash, :git_repo_url, :source_version,
+                :start_time, :status_code, :trigger
 
     # attrs from git info
     attr_reader :author_email, :author_name, :committer_email, :committer_name,
@@ -31,7 +32,9 @@ module CodeBuildNotifier
       commit_hash: ENV['CODEBUILD_RESOLVED_SOURCE_VERSION'],
       git_repo: ENV['CODEBUILD_SOURCE_REPO_URL'],
       head_ref: ENV['CODEBUILD_WEBHOOK_HEAD_REF'],
+      start_time: ENV['CODEBUILD_START_TIME'],
       status_code: ENV['CODEBUILD_BUILD_SUCCEEDING'],
+      source_version: ENV['CODEBUILD_SOURCE_VERSION'],
       trigger: ENV['CODEBUILD_WEBHOOK_TRIGGER']
     )
       @build_id = build_id
@@ -39,6 +42,8 @@ module CodeBuildNotifier
       # Handle repos specified with and without optional .git suffix.
       @git_repo_url = git_repo.to_s.gsub(/\.git\z/, '')
       @head_ref = head_ref
+      @source_version = source_version
+      @start_time = start_time || (Time.now.to_f * 1_000).to_i
       @status_code = status_code
       @trigger = trigger
 
@@ -117,6 +122,7 @@ module CodeBuildNotifier
         committer_name: committer_name,
         git_repo_url: git_repo_url,
         project_code: project_code,
+        start_time: start_time,
         status: status
       }
     end

--- a/lib/codebuild-notifier/current_build.rb
+++ b/lib/codebuild-notifier/current_build.rb
@@ -106,6 +106,21 @@ module CodeBuildNotifier
       end
     end
 
+    def history_fields
+      {
+        author_email: author_email,
+        author_name: author_name,
+        build_id: build_id,
+        commit_hash: commit_hash,
+        commit_subject: commit_message_subject,
+        committer_email: committer_email,
+        committer_name: committer_name,
+        git_repo_url: git_repo_url,
+        project_code: project_code,
+        status: status
+      }
+    end
+
     private def git_info
       Git.current_commit
     end

--- a/lib/codebuild-notifier/current_build.rb
+++ b/lib/codebuild-notifier/current_build.rb
@@ -78,7 +78,7 @@ module CodeBuildNotifier
     end
 
     def for_pr?
-      %r{^pr/}.match?(trigger.to_s)
+      %r{^pr/}.match?(source_version.to_s)
     end
 
     # source_id, the primary key, is a composite of project_code and

--- a/lib/codebuild-notifier/current_build.rb
+++ b/lib/codebuild-notifier/current_build.rb
@@ -17,8 +17,12 @@
 
 module CodeBuildNotifier
   class CurrentBuild
-    attr_reader :build_id, :commit_hash, :git_repo_url, :status_code, :trigger
     attr_accessor :previous_build
+    attr_reader :build_id, :commit_hash, :git_repo_url, :status_code, :trigger
+
+    # attrs from git info
+    attr_reader :author_email, :author_name, :committer_email, :committer_name,
+                :commit_message_subject, :short_hash
 
     # Default values are extracted from CODEBUILD_* ENV vars present in each
     # CodeBuild # job container.
@@ -37,6 +41,10 @@ module CodeBuildNotifier
       @head_ref = head_ref
       @status_code = status_code
       @trigger = trigger
+
+      @short_hash, @author_name, @author_email,
+        @committer_name, @committer_email,
+        @commit_message_subject = git_info
     end
 
     # If launched via retry, the webhook head ref env var is blank,
@@ -96,6 +104,10 @@ module CodeBuildNotifier
       else
         trigger
       end
+    end
+
+    private def git_info
+      Git.current_commit
     end
   end
 end

--- a/lib/codebuild-notifier/dynamo_base.rb
+++ b/lib/codebuild-notifier/dynamo_base.rb
@@ -1,0 +1,57 @@
+# codebuild-notifier
+# Copyright © 2018 Adam Alboyadjian <adam@cassia.tech>
+# Copyright © 2018 Vista Higher Learning, Inc.
+#
+# codebuild-notifier is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# codebuild-notifier is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with codebuild-notifier.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'active_support'
+require 'active_support/core_ext'
+require 'aws-sdk-dynamodb'
+require 'hashie'
+
+module CodeBuildNotifier
+  class DynamoBase
+    attr_reader :config, :current_build
+
+    delegate :dynamo_table, to: :config
+
+    def initialize(config, build)
+      @config = config
+      @current_build = build
+    end
+
+    private def update_item(updates)
+      dynamo_client.update_item(
+        updates.merge(table_name: dynamo_table)
+      )
+    end
+
+    private def dynamo_client
+      @dynamo_client || Aws::DynamoDB::Client.new(region: config.region)
+    end
+
+    private def hash_to_dynamo_update(hash)
+      update = hash.each_with_object(
+        expression_attribute_names: {},
+        expression_attribute_values: {},
+        update_expression: []
+      ) do |(key, value), memo|
+        memo[:expression_attribute_names]["##{key}"] = key.to_s
+        memo[:expression_attribute_values][":#{key}"] = value
+        memo[:update_expression] << "##{key} = :#{key}"
+      end
+      update.merge(update_expression: "SET #{update[:update_expression].join(', ')}")
+    end
+  end
+end

--- a/lib/codebuild-notifier/git.rb
+++ b/lib/codebuild-notifier/git.rb
@@ -18,7 +18,7 @@
 module CodeBuildNotifier
   module Git
     def current_commit
-      `git show -s --format='%h|%aN|%aE|%cE|%s'`.chomp.split('|')
+      `git show -s --format='%h|%aN|%aE|%cN|%cE|%s'`.chomp.split('|')
     end
     module_function :current_commit
   end

--- a/lib/codebuild-notifier/project_summary.rb
+++ b/lib/codebuild-notifier/project_summary.rb
@@ -1,0 +1,125 @@
+# codebuild-notifier
+# Copyright © 2018 Adam Alboyadjian <adam@cassia.tech>
+# Copyright © 2018 Vista Higher Learning, Inc.
+#
+# codebuild-notifier is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# codebuild-notifier is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with codebuild-notifier.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'digest'
+
+module CodeBuildNotifier
+  class ProjectSummary < DynamoBase
+    # Creates entries in a partition key with hardcoded primary key.
+    # Within the partition key, there is one record for each github repo.
+    # The 'projects' field in that record is a Map data type, keyed off
+    # project code, containing the status of the last build for that code.
+    def update
+      return unless whitelisted_branch?
+
+      updates = project_summary_entry
+      yield updates if block_given?
+      update_item(updates)
+    end
+
+    private def whitelisted_branch?
+      config.whitelist_branches.include?(current_build.branch_name)
+    end
+
+    private def project_summary_entry
+      {
+        key: { source_id: source_id, version_key: version_key },
+        expression_attribute_names: attr_names,
+        expression_attribute_values: attr_values,
+        update_expression: update_expression
+      }
+    end
+
+    private def new_record?
+      return @new_record if defined?(@new_record)
+
+      item = dynamo_client.get_item(
+        key: {
+          'source_id' => source_id, 'version_key' => version_key
+        },
+        table_name: dynamo_table
+      ).item
+      @new_record = item.nil?
+    end
+
+    private def source_id
+      'project_summary'
+    end
+
+    # The repo url isn't a good format to use as a URL param.
+    private def version_key
+      Digest::MD5.hexdigest(current_build.git_repo_url)
+    end
+
+    private def attr_names
+      {
+        '#commit_hash' => 'commit_hash',
+        '#git_repo_url' => 'git_repo_url',
+        '#timestamp' => 'timestamp',
+        '#projects' => 'projects'
+      }.merge(project_code_attr_name)
+    end
+
+    # For an existing record, the project key already exists, so
+    # an attribute name is needed to be able to update the nested item
+    # path. For a new record, the project code is specified as the root
+    # key of the value assigned to the projects field.
+    private def project_code_attr_name
+      if new_record?
+        {}
+      else
+        { '#project_code' => current_build.project_code }
+      end
+    end
+
+    private def attr_values
+      {
+        ':build_status' => status_value,
+        ':commit_hash' => source_id,
+        ':git_repo_url' => current_build.git_repo_url,
+        ':timestamp' => current_build.start_time.to_i
+      }
+    end
+
+    private def status_map
+      {
+        'build_id' => current_build.build_id,
+        'status' => current_build.status,
+        'timestamp' => current_build.start_time.to_i
+      }
+    end
+
+    # If a record already exists, we can address the nested item path for
+    # the current project directly and just store the updated status.
+    # Otherwise, we have to create a new map object in the projects field.
+    private def status_value
+      if new_record?
+        { current_build.project_code => status_map }
+      else
+        status_map
+      end
+    end
+
+    private def update_expression
+      projects_key = new_record? ? '#projects' : '#projects.#project_code'
+      'SET #commit_hash = :commit_hash, ' \
+      '#timestamp = :timestamp, ' \
+      '#git_repo_url = :git_repo_url, ' \
+      "#{projects_key} = :build_status"
+    end
+  end
+end

--- a/lib/codebuild-notifier/slack_message.rb
+++ b/lib/codebuild-notifier/slack_message.rb
@@ -17,16 +17,14 @@
 
 module CodeBuildNotifier
   class SlackMessage
-    attr_reader :author_email, :author_name, :build, :committer_email,
-                :commit_message_subject, :config, :short_hash
+    attr_reader :build, :config
 
-    delegate :source_ref, to: :build
+    delegate :author_email, :author_name, :committer_email,
+             :commit_message_subject, :short_hash, :source_ref, to: :build
 
     def initialize(build, config)
       @build = build
       @config = config
-      @short_hash, @author_name, @author_email,
-        @committer_email, @commit_message_subject = git_info
     end
 
     def payload
@@ -44,10 +42,6 @@ module CodeBuildNotifier
 
     def additional_channel
       !build.for_pr? && config.additional_channel
-    end
-
-    private def git_info
-      Git.current_commit
     end
 
     private def slack_color

--- a/spec/lib/code_build_notifier/build_history_spec.rb
+++ b/spec/lib/code_build_notifier/build_history_spec.rb
@@ -48,6 +48,10 @@ describe CodeBuildNotifier::BuildHistory do
     instance_double(CodeBuildNotifier::ProjectSummary, update: true)
   end
 
+  let(:branch_entry) do
+    instance_double(CodeBuildNotifier::BranchEntry, update: true)
+  end
+
   before do
     allow(Aws::DynamoDB::Client).to receive(:new).and_return(dynamo_client)
   end
@@ -59,6 +63,8 @@ describe CodeBuildNotifier::BuildHistory do
       allow(dynamo_client).to receive(:update_item)
       allow(CodeBuildNotifier::ProjectSummary).to receive(:new)
         .and_return(project_summary)
+      allow(CodeBuildNotifier::BranchEntry).to receive(:new)
+        .and_return(branch_entry)
     end
 
     it 'calls update_item on the dynamo table specified in config' do
@@ -122,6 +128,21 @@ describe CodeBuildNotifier::BuildHistory do
       history.write_entry(source_id)
 
       expect(project_summary).to have_received(:update)
+    end
+
+    it 'insantiates a new BranchEntry instance, passing in config and ' \
+       'current build' do
+      history.write_entry(source_id)
+
+      expect(CodeBuildNotifier::BranchEntry).to have_received(:new).with(
+        config, build
+      )
+    end
+
+    it 'updates the branch entry' do
+      history.write_entry(source_id)
+
+      expect(branch_entry).to have_received(:update)
     end
 
     context 'when the build was launched by Retry command,' do

--- a/spec/lib/code_build_notifier/current_build_spec.rb
+++ b/spec/lib/code_build_notifier/current_build_spec.rb
@@ -9,6 +9,36 @@ describe CodeBuildNotifier::CurrentBuild do
       source_ref: previous_source_ref
     )
   end
+  let(:author_email) { 'velma@dinkley.org' }
+  let(:author_name) { 'Velma Dinkley' }
+  let(:commit_subject) { 'Patch holes in van' }
+  let(:committer_email) { 'daphne@blake.org' }
+  let(:committer_name) { 'Daphne Blake' }
+  let(:short_hash) { 'e397ece' }
+
+  before do
+    allow(CodeBuildNotifier::Git).to receive(:current_commit).and_return(
+      [
+        short_hash,
+        author_name,
+        author_email,
+        committer_name,
+        committer_email,
+        commit_subject
+      ]
+    )
+  end
+
+  describe 'attributes from git' do
+    let(:build) { described_class.new }
+
+    specify { expect(build.author_email).to eq(author_email) }
+    specify { expect(build.author_name).to eq(author_name) }
+    specify { expect(build.commit_message_subject).to eq(commit_subject) }
+    specify { expect(build.committer_email).to eq(committer_email) }
+    specify { expect(build.committer_name).to eq(committer_name) }
+    specify { expect(build.short_hash).to eq(short_hash) }
+  end
 
   describe '#git_repo_url' do
     it 'removes .git from the end of a git repo specified with .git' do

--- a/spec/lib/code_build_notifier/current_build_spec.rb
+++ b/spec/lib/code_build_notifier/current_build_spec.rb
@@ -128,20 +128,20 @@ describe CodeBuildNotifier::CurrentBuild do
   end
 
   describe '#for_pr?' do
-    it 'is true if trigger starts with "pr/"' do
-      expect(described_class.new(trigger: 'pr/100')).to be_for_pr
+    it 'is true if source_version starts with "pr/"' do
+      expect(described_class.new(source_version: 'pr/100')).to be_for_pr
     end
 
-    it 'is false if trigger contains, but does not start with "pr/"' do
-      expect(described_class.new(trigger: 'branch/pr/100')).not_to be_for_pr
+    it 'is false if source_version contains, but does not start with "pr/"' do
+      expect(described_class.new(source_version: 'branch/pr/100')).not_to be_for_pr
     end
 
-    it 'is false if trigger is nil' do
-      expect(described_class.new(trigger: nil)).not_to be_for_pr
+    it 'is false if source_version is nil' do
+      expect(described_class.new(source_version: nil)).not_to be_for_pr
     end
 
-    it 'is false if trigger is empty string' do
-      expect(described_class.new(trigger: '')).not_to be_for_pr
+    it 'is false if source_version is empty string' do
+      expect(described_class.new(source_version: '')).not_to be_for_pr
     end
   end
 

--- a/spec/lib/code_build_notifier/slack_message_spec.rb
+++ b/spec/lib/code_build_notifier/slack_message_spec.rb
@@ -16,10 +16,15 @@ describe CodeBuildNotifier::SlackMessage do
   let(:build) do
     instance_double(
       CodeBuildNotifier::CurrentBuild,
+      author_email: author_email,
+      author_name: author_name,
       build_id: build_id,
       commit_hash: commit_hash,
+      commit_message_subject: commit_subject,
+      committer_email: committer_email,
       git_repo_url: git_repo,
       project_code: project_code,
+      short_hash: short_hash,
       source_ref: source_ref,
       status: status
     )
@@ -36,17 +41,13 @@ describe CodeBuildNotifier::SlackMessage do
 
   describe '#recipients' do
     it 'returns author email and commiter email if they are different' do
-      allow(CodeBuildNotifier::Git).to receive(:current_commit).and_return(
-        [short_hash, author_name, author_email, committer_email, commit_subject]
-      )
+      allow(build).to receive(:committer_email).and_return(committer_email)
 
       expect(message.recipients).to eq([author_email, committer_email])
     end
 
     it 'returns only one value if author email and commiter email are equal ' do
-      allow(CodeBuildNotifier::Git).to receive(:current_commit).and_return(
-        [short_hash, author_name, author_email, author_email, commit_subject]
-      )
+      allow(build).to receive(:committer_email).and_return(author_email)
 
       expect(message.recipients).to eq([author_email])
     end
@@ -80,12 +81,6 @@ describe CodeBuildNotifier::SlackMessage do
   end
 
   describe '#payload' do
-    before do
-      allow(CodeBuildNotifier::Git).to receive(:current_commit).and_return(
-        [short_hash, author_name, author_email, committer_email, commit_subject]
-      )
-    end
-
     it 'includes the name of the commit author in the fallback and title keys' do
       expect(
         [message.payload[:fallback], message.payload[:title]]


### PR DESCRIPTION
Instead of having one record for each pull request or branch, and updating its status for each build, create an append-only history of builds for each branch.  
- Add additional information to each build entry to facilitate displaying the history details via a web interface.
- Create a record for each repo containing a summary of the projects for that repo, along with the last status for each project.
- Create a record for each branch or PR, updated with the last status for that branch/pr.

TODO: 
1. Add specs for ProjectSummary and BranchEntry
1. ~~Update README with new dynamo schema~~
