### PR TITLE
gems: Update rails to 6.0.3.1 because of CVE-2020-8165.

### DIFF
--- a/codebuild-notifier.gemspec
+++ b/codebuild-notifier.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
     file.match(%r{^(test|spec|features)/})
   end
 
-  spec.add_dependency 'activesupport', '> 2.0', '< 6.0'
+  spec.add_dependency 'activesupport', '~> 6.0.3.1'
   spec.add_dependency 'aws-sdk-dynamodb', '~> 1.16'
   spec.add_dependency 'aws-sdk-secretsmanager', '~> 1.19'
   spec.add_dependency 'hashie', '> 1.0', '< 4.0'


### PR DESCRIPTION
https://vistahl.atlassian.net/browse/MAE-52731